### PR TITLE
Add prek/pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.10
+    hooks:
+      - id: ruff-check
+        args: ["--fix", "--show-fixes"]
+      - id: ruff-format


### PR DESCRIPTION
I see two solutions for enforcing ruff check/format:
* Enable the [pre-commit.ci](https://pre-commit.ci/) service in this repository's settings.
* Use the [prek](https://prek.j178.dev/) GitHub Action:
  https://github.com/j178/prek-action